### PR TITLE
Remove localhost from contract web link

### DIFF
--- a/docs/1. intro.md
+++ b/docs/1. intro.md
@@ -10,7 +10,7 @@ Two types of contract matches (verifications) are defined: **full (perfect) matc
 Sourcify has 4 main components:
 
 - **UI** at https://sourcify.dev.
-- **Decentralized contract repository** of verified contracts on [IPFS](/docs/repository#ipfs), also directly accessible [on web](http://localhost:3000/docs/repository#web).
+- **Decentralized contract repository** of verified contracts on [IPFS](/docs/repository#ipfs), also directly accessible [on web](/docs/repository#web).
 - **Verification [API](/docs/api)** for [supported chains](/docs/chains).
 - **Monitoring service** for [supported chains](/docs/chains) to automatically verify deployed contracts with source code published on IPFS.
 


### PR DESCRIPTION
Unsure if it was intentional to have the link to a locally running host in the deployed docs.