### PR TITLE
`chains.json` link in 'Requesting Chain Support' page 404ing

### DIFF
--- a/docs/95. requestChainSupport.md
+++ b/docs/95. requestChainSupport.md
@@ -8,7 +8,7 @@ Do you want to verify contracts on an EVM chain (or chains)? Great! We don't wan
 
 If you still want to request an EVM chain(s) to be supported by Sourcify, please open a pull request with the instructions below for a speedy process:
 
-1.  Make sure the new chains are listed in [chains.json](https://github.com/ethereum/sourcify/blob/staging/src/chains.json) but **this file should not be edited**. It is kept in sync with [chainid.network](https://chainid.network/chains.json) (github: [ethereum-lists/chains](https://github.com/ethereum-lists/chains)) periodically. If your chains are not included, please first add your chains to the [ethereum-lists/chains](https://github.com/ethereum-lists/chains) repository first.
+1.  Make sure the new chains are listed in [chains.json](https://github.com/ethereum/sourcify/blob/staging/services/server/src/chains.json) but **this file should not be edited**. It is kept in sync with [chainid.network](https://chainid.network/chains.json) (github: [ethereum-lists/chains](https://github.com/ethereum-lists/chains)) periodically. If your chains are not included, please first add your chains to the [ethereum-lists/chains](https://github.com/ethereum-lists/chains) repository first.
 
 1.  Fork the repository. Branch out from the **staging** branch with name e.g. `add-chain-1-11155111` for Ethereum Mainnet (1) and Sepolia (11155111) or `add-chain-1` for Ethereum Mainnet only. This branch name format is required for automated testing. You can also add more than one chains in one pull request, granted you added tests for each.
 


### PR DESCRIPTION
Updated to what I think the correct file is. Guessing it just got moved at some stage