### PR TITLE
Add info box for new match level naming

### DIFF
--- a/docs/3. Verification/2 .fullVsPartialMatch.md
+++ b/docs/3. Verification/2 .fullVsPartialMatch.md
@@ -21,6 +21,17 @@ Different compilation settings i.e. compiler versions, optimization runs result 
 
 If the bytecode from recompiling the contract with the given source code files and the metadata correspond to the bytecode of the contract of the given address and chain, it will be a **match**. Sourcify defines two types of matches upon verifying contracts: **full (perfect) matches** and **partial matches**.
 
+:::info Info
+
+The match levels will be renamed in Sourcify's API v2:
+
+- Full match will be renamed to **exact match**
+- Partial match will be renamed to **match**
+
+This only concerns the naming, and the description of the match levels on this page will still be valid.
+
+:::
+
 ## Full (Perfect) Matches
 
 <AvailableOnlyForSolidityAdmonition description="Vyper contracts don't support full matches because Vyper doesn't include the metadata hash in the bytecode."/>


### PR DESCRIPTION
As the lookup of API v2 was already released, I wanted to add some info about the new naming of the match levels.