### PR TITLE
Add live dataset size stats to Downloads and Database pages

### DIFF
--- a/docs/4. Contract dataset/1. Download the dataset.md
+++ b/docs/4. Contract dataset/1. Download the dataset.md
@@ -6,8 +6,6 @@ title: Download the dataset
 
 import DatasetStats from '../DatasetStats.jsx';
 
-<DatasetStats variant="full" />
-
 :::warning
 
 The previous Parquet export format v1 is now deprecated. See the [note](/docs/repository/download-dataset/#legacy-format-v1) below. Please follow the [instructions](/docs/repository/download-dataset/#export-v2-format) for the new v2 format.
@@ -17,6 +15,10 @@ The previous Parquet export format v1 is now deprecated. See the [note](/docs/re
 The entire Sourcify Database is exported regularly as [Parquet](https://github.com/apache/parquet-format) files, a modern columnar data format. Parquet files are compressed, efficient to query, and widely supported by data tools. ([Quick tutorial](https://www.datacamp.com/tutorial/apache-parquet)).
 
 The export is hosted on Google Cloud Storage and accessible via an S3-compatible API at [export.sourcify.dev](https://export.sourcify.dev/). The export is based on the structure of the [Verifier Alliance database export](https://verifieralliance.org/docs/download).
+
+## Overview
+
+<DatasetStats variant="full" />
 
 ## Export v2 Format
 

--- a/docs/4. Contract dataset/1. Download the dataset.md
+++ b/docs/4. Contract dataset/1. Download the dataset.md
@@ -4,6 +4,10 @@ slug: /repository/download-dataset/
 title: Download the dataset
 ---
 
+import DatasetStats from '../DatasetStats.jsx';
+
+<DatasetStats variant="full" />
+
 :::warning
 
 The previous Parquet export format v1 is now deprecated. See the [note](/docs/repository/download-dataset/#legacy-format-v1) below. Please follow the [instructions](/docs/repository/download-dataset/#export-v2-format) for the new v2 format.

--- a/docs/6. Sourcify in depth/3. Database.md
+++ b/docs/6. Sourcify in depth/3. Database.md
@@ -4,7 +4,11 @@ slug: /repository/sourcify-database/
 title: Database
 ---
 
+import DatasetStats from '../DatasetStats.jsx';
+
 # Sourcify Database
+
+<DatasetStats variant="totals" />
 
 Sourcify Database is the main storage backend for Sourcify. It is a PostgreSQL database that follows the [Verifier Alliance Schema](https://github.com/verifier-alliance/database-specs) as its base with few modifications.
 

--- a/docs/DatasetStats.jsx
+++ b/docs/DatasetStats.jsx
@@ -1,0 +1,109 @@
+import React, { useEffect, useState } from "react";
+
+function formatBytes(bytes) {
+  if (bytes >= 1e12) return (bytes / 1e12).toFixed(1) + " TB";
+  if (bytes >= 1e9) return (bytes / 1e9).toFixed(1) + " GB";
+  if (bytes >= 1e6) return (bytes / 1e6).toFixed(1) + " MB";
+  return (bytes / 1e3).toFixed(1) + " KB";
+}
+
+function timeAgo(isoDate) {
+  const diff = Math.floor((Date.now() - new Date(isoDate).getTime()) / 1000);
+  if (diff < 3600) return `${Math.floor(diff / 60)}m ago`;
+  if (diff < 86400) return `${Math.floor(diff / 3600)}h ago`;
+  return `${Math.floor(diff / 86400)}d ago`;
+}
+
+/**
+ * Fetches and displays parquet export and Postgres database sizes from stats.json.
+ *
+ * @param {"totals" | "full"} [variant="full"]
+ *   "totals" - only show the two headline numbers (used on the Database page).
+ *   "full"   - show totals + per-table breakdown (used on the Downloads page).
+ */
+export default function DatasetStats({ variant = "full" }) {
+  const [stats, setStats] = useState(null);
+  const [error, setError] = useState(false);
+
+  useEffect(() => {
+    fetch("https://export.sourcify.dev/v2/stats.json")
+      .then((res) => {
+        if (!res.ok) throw new Error(res.statusText);
+        return res.json();
+      })
+      .then(setStats)
+      .catch(() => setError(true));
+  }, []);
+
+  if (error) {
+    return (
+      <p style={{ color: "var(--ifm-color-warning)" }}>
+        Could not load live dataset stats. Check{" "}
+        <a href="https://export.sourcify.dev/v2/stats.json" target="_blank" rel="noopener noreferrer">
+          export.sourcify.dev/v2/stats.json
+        </a>{" "}
+        directly.
+      </p>
+    );
+  }
+
+  if (!stats) {
+    return <p>Loading dataset stats…</p>;
+  }
+
+  const totals = (
+    <div style={{ display: "flex", gap: "2rem", flexWrap: "wrap", margin: "1rem 0" }}>
+      <div>
+        <strong style={{ fontSize: "1.4rem" }}>{formatBytes(stats.parquet.totalBytes)}</strong>
+        <div style={{ fontSize: "0.85rem", color: "var(--ifm-color-content-secondary)" }}>
+          Parquet export size (zstd compression) · updated {timeAgo(stats.generatedAt)}
+        </div>
+      </div>
+      <div>
+        <strong style={{ fontSize: "1.4rem" }}>{formatBytes(stats.database.totalBytes)}</strong>
+        <div style={{ fontSize: "0.85rem", color: "var(--ifm-color-content-secondary)" }}>
+          Postgres database size (includes indexes &amp; TOAST)
+        </div>
+      </div>
+    </div>
+  );
+
+  if (variant === "totals") {
+    return totals;
+  }
+
+  // full variant: totals + per-table breakdown
+  const tableNames = Object.keys(stats.parquet.tables);
+
+  return (
+    <div>
+      {totals}
+      <table>
+        <thead>
+          <tr>
+            <th style={{ textAlign: "left" }}>Table</th>
+            <th style={{ textAlign: "right" }}>Parquet size</th>
+            <th style={{ textAlign: "right" }}>Parquet files</th>
+            <th style={{ textAlign: "right" }}>DB size</th>
+          </tr>
+        </thead>
+        <tbody>
+          {tableNames.map((table) => (
+            <tr key={table}>
+              <td>
+                <code>{table}</code>
+              </td>
+              <td style={{ textAlign: "right" }}>{formatBytes(stats.parquet.tables[table].bytes)}</td>
+              <td style={{ textAlign: "right" }}>{stats.parquet.tables[table].fileCount}</td>
+              <td style={{ textAlign: "right" }}>{formatBytes(stats.database.tables[table]?.bytes ?? 0)}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      <p style={{ fontSize: "0.8rem", color: "var(--ifm-color-content-secondary)", marginTop: "0.5rem" }}>
+        DB sizes include indexes and TOAST. The total DB size is slightly larger than the sum of tables
+        because it also includes system catalogs and unallocated space.
+      </p>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- Adds a new `docs/DatasetStats.jsx` component that fetches `https://export.sourcify.dev/v2/stats.json` client-side at render time and displays:
  - Two headline totals: parquet export size (compressed) and Postgres DB size
  - A per-table breakdown table (Table | Parquet size | Parquet files | DB size)
- The component accepts a `variant` prop:
  - `variant="full"` (default): totals + per-table breakdown — used on the **Downloads** page
  - `variant="totals"`: totals only — used on the **Database** page
- Inserts the component into:
  - `docs/4. Contract dataset/1. Download the dataset.md` — above the deprecation notice
  - `docs/6. Sourcify in depth/3. Database.md` — below the page heading
- Follows the existing `EmbedReadme.jsx` pattern (client-side `useEffect` fetch, SSR-safe).

> **Requires** verifier-alliance/parquet-export#17 to be merged and deployed first so that `v2/stats.json` is published at `export.sourcify.dev`.

## Test plan

- [ ] `yarn start`, visit `/docs/repository/download-dataset/` — confirm totals + per-table table render.
- [ ] Visit `/docs/repository/sourcify-database/` — confirm only the two totals render.
- [ ] `yarn build` passes with `onBrokenLinks: "throw"`.
- [ ] Simulate network failure; confirm graceful fallback message appears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)