### PR TITLE
docs: update chain support instructions to point to sourcify-chains repo

### DIFF
--- a/docs/3. Requesting Chain Support.md
+++ b/docs/3. Requesting Chain Support.md
@@ -5,13 +5,13 @@ title: Requesting Chain Support
 
 # Requesting Chain Support
 
-To request an EVM chain(s) to be supported by Sourcify, please open a pull request with the instructions below for a speedy process:
+To request an EVM chain(s) to be supported by Sourcify, please open a pull request in the [sourcify-chains](https://github.com/argotorg/sourcify-chains) repository with the instructions below:
 
-1.  Make sure the new chains are listed in [chains.json](https://github.com/argotorg/sourcify/blob/staging/services/server/src/chains.json) but **this file should not be edited**. It is kept in sync with [chainid.network](https://chainid.network/chains.json) (github: [ethereum-lists/chains](https://github.com/ethereum-lists/chains)) periodically. If your chains are not included, please first add your chains to the [ethereum-lists/chains](https://github.com/ethereum-lists/chains) repository first.
+1.  Make sure the new chains are listed in [chains.json](https://github.com/ethereum-lists/chains/blob/master/_data/chains) (github: [ethereum-lists/chains](https://github.com/ethereum-lists/chains)). If your chain is not included there, please add it first. It will be picked up automatically in the next `sourcify-chains` generation run.
 
-1.  Fork the repository. Branch out from the **staging** branch with name e.g. `add-chain-1-11155111` for Ethereum Mainnet (1) and Sepolia (11155111) or `add-chain-1` for Ethereum Mainnet only. This branch name format is required for automated testing. You can also add more than one chains in one pull request, granted you added tests for each.
+1.  Fork the [sourcify-chains](https://github.com/argotorg/sourcify-chains) repository. Branch out from the **main** branch with a name like `add-chain-1-11155111` for Ethereum Mainnet (1) and Sepolia (11155111), or `add-chain-1` for a single chain. This branch name format is used to identify new chains in automated testing.
 
-1.  Add the chain details in [sourcify-chains-default.json](https://github.com/argotorg/sourcify/blob/staging/services/server/src/sourcify-chains-default.json) similar to other chains with `supported: true`.
+1.  Add the chain details to [chain-overrides.json](https://github.com/argotorg/sourcify-chains/blob/main/chain-overrides.json) (for chains already present in `chainid.network`) or [additional-chains.json](https://github.com/argotorg/sourcify-chains/blob/main/additional-chains.json) (for chains not yet in `chainid.network`). Set `supported: true` and fill in the relevant fields.
 
 <details>
       <summary>
@@ -81,19 +81,15 @@ To request an EVM chain(s) to be supported by Sourcify, please open a pull reque
 
 </details>
 
-1.  Install and build the project with `npm install` and `npx lerna run build`.
-
 1.  Provide test contracts:
-    1. If your chain has an instance of CreateX ([deployments](https://createx.rocks/deployments)) or Multicall ([deployments](https://www.multicall3.com/deployments)), you can skip this step.
+    1. If your chain has an instance of CreateX ([deployments](https://createx.rocks/deployments)) or Multicall3 ([deployments](https://www.multicall3.com/deployments)), you can skip this step.
     1. If not, deploy a Storage.sol contract:
-       1. Using the provided script: You can easily deploy both contracts with an account private key using the provided [`script`](https://github.com/argotorg/sourcify/blob/staging/services/server/test/chains/deployContracts.ts), that can be run with `ts-node`. Inside `services/server`, run `npx ts-node test/chains/deployContracts.ts --help` for more information.
+       1. Using the provided script: Deploy the contract with an account private key using the [`deployContracts.ts` script](https://github.com/argotorg/sourcify-chains/blob/main/scripts/deployContracts.ts). Inside the `sourcify-chains` repo, run `npx tsx scripts/deployContracts.ts --help` for more information.
        1. If you can't or don't want to paste your private key, deploy [this contract in the Thirdweb dashboard](https://thirdweb.com/0xAA6042aa65eb93C6439cDaeBC27B3bd09c5DFe94/Storage) through the wallet of your choice.
-       1. Add the contract address on your chain to [storage-contract-chain-addresses.json](https://github.com/argotorg/sourcify/blob/staging/services/server/test/chains/sources/storage-contract-chain-addresses.json)
+       1. Add the contract address on your chain to [storage-contract-chain-addresses.json](https://github.com/argotorg/sourcify-chains/blob/main/tests/fixtures/storage-contract-chain-addresses.json)
 
-1.  To test locally run `export NEW_CHAIN_ID=1,11155111 && npm run test-local:chains` inside `services/server`. Note that this requires `docker-compose`.
+1.  If the tests pass, open a pull request targeting the `sourcify-chains` **main** branch.
 
-1.  If the tests pass, open a pull request targeting the Sourcify **staging** branch.
+If the tests pass, the chain will be added to the Sourcify server configuration quickly. The server picks up the updated chain config from the `sourcify-chains` repo on each deployment.
 
-If the tests pass, the chain will be added quickly. The chain will be added to production (master branch) with the next release, which usually happens in 1-2 weeks.
-
-_If the tests for a chain will fail two weeks in a row, we will assume the chain is not being maintained and remove it from the supported chains list. The tests can be seen [in CircleCI](https://app.circleci.com/pipelines/github/argotorg/sourcify?branch=master) under "test-chains-regularly" workflow_
+_If the tests for a chain fail two weeks in a row, we will assume the chain is not being maintained and remove it from the supported chains list. The automated tests run twice daily and can be seen under the [integration-tests](https://github.com/argotorg/sourcify-chains/actions/workflows/integration-tests.yml) workflow._

--- a/docs/5. Verify on Sourcify/2. Verify via UI.mdx
+++ b/docs/5. Verify on Sourcify/2. Verify via UI.mdx
@@ -101,7 +101,7 @@ The verification UI will parse the files and give you a list of contracts to cho
 
 ### (Optional) Creation Transaction Hash
 
-Sourcify needs to find the transaction the contract was deployed in to get the creation bytecode. We get this information from different sources like block explorers (see [here](https://github.com/argotorg/sourcify/blob/staging/services/server/src/sourcify-chains-default.json)). You can still provide a creation transaction hash manually if you want to, or if Sourcify fails to verify via creation bytecode.
+Sourcify needs to find the transaction the contract was deployed in to get the creation bytecode. We get this information from different sources like block explorers (see [here](https://github.com/argotorg/sourcify-chains/blob/main/sourcify-chains-default.json)). You can still provide a creation transaction hash manually if you want to, or if Sourcify fails to verify via creation bytecode.
 
 ### Hardhat/Foundry build-info files
 

--- a/docs/8. Run your instance/6. Database migrations.md
+++ b/docs/8. Run your instance/6. Database migrations.md
@@ -119,7 +119,7 @@ In the process of the migration:
   - III. ⚠ In the configuration of `sourcify-server-migration`, change the path of repositoryV1 to a new path: this is the _new_repositoryV1_. Don’t write in _current_repositoryV1_!
   - IV. Start the new `sourcify-server-migration` instance
 - **b. Find unsupported chains**
-  - I. From `services/server/src/sourcify-chains-default.json` or the `sourcify-chains` file that you are using, find all the chainIds of unsupported chains.
+  - I. From the [sourcify-chains-default.json](https://github.com/argotorg/sourcify-chains/blob/main/sourcify-chains-default.json) or the `sourcify-chains` file that you are using, find all the chainIds of unsupported chains.
   - II. Prepare them formatted in a list separated by a comma. E.g. `0,3,4,42,77,300,534,421613,4216137055,420,28,43,486217935,356256156,103090,420666,420420,99,592,8217,28528,14,421611,69,167005,167006`
   - III. ⚠ Remember to include chainId 0 in this list
 - **c. Start the synchronization script**


### PR DESCRIPTION
## Summary

- Rewrites "Requesting Chain Support" (`docs/3. Requesting Chain Support.md`) to reflect the new contribution flow now that chain config and tests live in [argotorg/sourcify-chains](https://github.com/argotorg/sourcify-chains)
- Fixes two stale links pointing at `services/server/src/sourcify-chains-default.json` (that file no longer exists in the monorepo since it was moved to sourcify-chains)

## New contribution flow

Contributors now open PRs against `sourcify-chains` (not the main sourcify repo):
- Add chain to `chain-overrides.json` or `additional-chains.json`
- Deploy `Storage.sol` via `npx tsx scripts/deployContracts.ts` if needed
- Add address to `tests/fixtures/storage-contract-chain-addresses.json`
- CI (`test-new-chain.yml`) runs automatically on the PR

## Companion PRs

- [sourcifyeth/sourcify-chains#66](https://github.com/sourcifyeth/sourcify-chains/pull/66) — adds the tests and workflows (**land first**)
- argotorg/sourcify branch `feat/remote-chain-config-v2` (PR #2709) — removes the old test files from the monorepo

**Draft — mark ready for review after the two companion PRs are merged.**

## Test plan

- [ ] `npm run build` (Docusaurus) passes with no broken links
- [ ] Links to sourcify-chains files resolve after companion PRs merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)