### PR TITLE
docs(database): document zksolc composite version string

### DIFF
--- a/docs/6. Sourcify in depth/3. Database.md
+++ b/docs/6. Sourcify in depth/3. Database.md
@@ -74,6 +74,7 @@ Other known inconsistencies in the data below (not planned to fix) are documente
   - version =< 0.3.0: The commit hash has 7 characters `0.3.0+commit.8a23feb`
   - version 0.3.1: No commit hash: `0.3.1`
   - version >= 0.3.2: The commit hash has 8 characters `0.3.2+commit.3b6a4117`
+- **zksolc (ZKsync EraVM)**: zksolc compilations need both a zksolc version and a solc backend version, so the `version` column stores a composite string of the form `zksolc:<zksolcVersion>;solc:<solcVersion>` (e.g. `zksolc:1.5.10;solc:0.8.26-1.0.2`). The `solc` part is the era-solc backend release `<solc>-<edition>` (the edition encodes the LLVM version), or an upstream `solc` (`0.8.26+commit…`) for older zksolc that allowed it.
 
 ## Download
 


### PR DESCRIPTION
Documents that zksolc (ZKsync EraVM) compilations store a composite `version` in `compiled_contracts.version`, of the form `zksolc:<zksolcVersion>;solc:<solcVersion>` (e.g. `zksolc:1.5.10;solc:0.8.26-1.0.2`). Added under the existing **Compiler versions** notes in the Database doc.

Context: this is the storage format introduced by the zksolc/EraVM verification work in Sourcify: https://github.com/argotorg/sourcify/pull/2788

🤖 Generated with [Claude Code](https://claude.com/claude-code)
