### PR TITLE
Add note that API v1 has been turned off

### DIFF
--- a/docs/1. API.md
+++ b/docs/1. API.md
@@ -10,6 +10,12 @@ import SwaggerContainer from "../src/components/SwaggerContainer";
 
 # API Documentation
 
+:::warning API v1 is turned off
+
+The legacy **v1 API has been completely turned off as of July 7, 2026**. Please migrate to the **v2 API** documented below. See the [API v1 Brownouts blog post](/blog/api-v1-brownouts) for details.
+
+:::
+
 Sourcify has two APIs:
 
 - [Server API](#server-api-documentation): The main API for Sourcify, used to verify contracts and get information about verified contracts under `https://sourcify.dev/server`.


### PR DESCRIPTION
Adds a warning admonition to the top of the API page noting that the legacy **v1 API was completely turned off on July 7, 2026**, directing users to the v2 API and linking to the [API v1 Brownouts blog post](/blog/api-v1-brownouts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)