### PR TITLE
security: pin GitHub Actions to full-length commit SHAs

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,14 +12,14 @@ jobs:
       id-token: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       - name: "auth"
-        uses: "google-github-actions/auth@v2"
+        uses: "google-github-actions/auth@c200f3691d83b41bf9bbd8638997a462592937ed" # v2.1.13
         with:
           workload_identity_provider: "projects/1019539084286/locations/global/workloadIdentityPools/github/providers/sourcify"
           service_account: "sourcify-docs-cd@sourcify-project.iam.gserviceaccount.com"
       - name: Set up Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3.9.1
         with:
           node-version: "22.4"
       - name: Install dependencies
@@ -27,11 +27,11 @@ jobs:
       - name: Build
         run: npm run build
       - name: "setup-gcloud"
-        uses: "google-github-actions/setup-gcloud@v2"
+        uses: "google-github-actions/setup-gcloud@e427ad8a34f8676edf47cf7d7925499adf3eb74f" # v2.2.1
       - name: "clear-bucket"
         run: gsutil -m rm gs://sourcify-docs-bucket/** || true
       - name: "upload-files"
-        uses: "google-github-actions/upload-cloud-storage@v2"
+        uses: "google-github-actions/upload-cloud-storage@c0f6160ff80057923ff50e5e567695cea181ec23" # v2.2.4
         with:
           path: "build"
           destination: "sourcify-docs-bucket"


### PR DESCRIPTION
## Summary

Part of the org-wide action pinning work (argotorg/sourcify#2898). Pins every GitHub Action in this repo to a full-length commit SHA.

Tags are mutable: whoever controls an action's repository can repoint `@v4` at different code at any time, and that code then runs in CI with this repo's secrets. A commit SHA can't be repointed.

Changed **1 workflow file(s)**: release.yaml 

Each pin keeps a trailing `# v4.4.0` comment showing the version it resolved to, so the readable version is still there. This matches the convention already used elsewhere in the org (e.g. `mikepenz/action-junit-report`).

## Nothing else changed

Versions are pinned **as they are today** — no upgrades bundled in. Where a workflow sits on an old major (several repos are still on `actions/checkout@v2` / `setup-node@v2`, which run on end-of-life runners), that deserves a separate upgrade PR rather than mixing a behaviour change into a security pin.

## Why now

The `sourcifyeth` org is enabling **Settings → Actions → General → Policies → "Require actions to be pinned to a full-length commit SHA"**. Once that's on, any workflow with an unpinned action fails. This should merge before that flip.

## Keeping pins fresh

Pinning without an updater means these SHAs go stale and stop picking up upstream security fixes. This repo has no Renovate config, so the pins are manual for now. Onboarding Renovate with `pinDigests: true` would keep them maintained — worth a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)