### PR TITLE
chore: add context7.json to claim the Context7 library

### DIFF
--- a/static/docs/context7.json
+++ b/static/docs/context7.json
@@ -1,0 +1,4 @@
+{
+  "url": "https://context7.com/websites/sourcify_dev",
+  "public_key": "pk_HiiA9OlLy1Bd0QgaG7iO0"
+}


### PR DESCRIPTION
Adds `static/docs/context7.json` so we can claim admin rights for the [sourcify_dev library on Context7](https://context7.com/websites/sourcify_dev).

## Why

Context7 verifies that we own the docs site before it gives us admin rights over the library. The check is: host a JSON file with a public key that Context7 generated, at a URL under `https://docs.sourcify.dev/docs`. Context7 then fetches that URL and compares the key.

## What changes

New file `static/docs/context7.json`:

```json
{
  "url": "https://context7.com/websites/sourcify_dev",
  "public_key": "pk_HiiA9OlLy1Bd0QgaG7iO0"
}
```

Docusaurus copies everything under `static/` to the build output as-is. So this file becomes `build/docs/context7.json` and is served at:

https://docs.sourcify.dev/docs/context7.json

I ran `npm run build` locally and confirmed the file lands at `build/docs/context7.json` with the correct content. It does not collide with any generated docs page, because the docs pages are directories with an `index.html` inside.

## After merge

Once `main` deploys, enter `https://docs.sourcify.dev/docs/context7.json` in the "Claim Library" dialog on Context7 and click **Claim Library**.

The `public_key` is a public value, meant to be published. It is not a secret.

🤖 Generated with [Claude Code](https://claude.com/claude-code)